### PR TITLE
表示名の設定

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,7 @@ Style/SymbolArray:
 Metrics/BlockLength:
   Exclude:
     - 'app/admin/*'
+    - "config/environments/**/*"
 
 Rails/Output:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "2.7.3"
 
 gem "bootsnap", ">= 1.4.4", require: false
+gem "enum_help"
 gem "jbuilder", "~> 2.7"
 gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
@@ -11,7 +12,6 @@ gem "rails", "~> 6.1.1"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem "enum_help"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rails", "~> 6.1.1"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
+gem "enum_help"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.9.4)
       devise (>= 4.7.1)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.0)
     globalid (0.4.2)
@@ -244,6 +246,7 @@ DEPENDENCIES
   byebug
   devise
   devise-i18n
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,15 @@
+ja:
+  genre: &genre
+    invisible: 非表示
+    basic: Basic
+    git: Git
+    ruby: Ruby
+    rails: Ruby on Rails
+    php: PHP
+
+  enums:
+    text:
+      genre: *genre
+    movie:
+      genre: *genre
+        


### PR DESCRIPTION
close #10 

## 実装内容
- `enum_help`の導入
- `genre`の表示名変更

## 参考資料
[やんばる教材：列挙型とセレクトボックス](https://www.yanbaru-code.com/texts/351)
[yamlの書き方(コメント, 配列, アンカー, エイリアス)](https://www.wakuwakubank.com/posts/488-it-yaml/)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 備考
`rubocop -a`の際に出てくる`Metrics/BlockLength`を表示されないように設定しましたが問題ないでしょうか？
