### PR TITLE
フラッシュの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,13 @@
 .mw-xl {
   max-width: 1200px;
 }
+
+// フラッシュ
+
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,4 @@
+<% flash.each do |flash_type, msg| %>
+  <p><%= msg %></p>
+  <hr>
+<% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |flash_type, msg| %>
-<div class="alert alert-primary" role="alert">
-  <p><%=  msg %></p>
+ <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
 </div>
-  <hr>
 <% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,4 +1,6 @@
 <% flash.each do |flash_type, msg| %>
-  <p><%= msg %></p>
+<div class="alert alert-primary" role="alert">
+  <p><%=  msg %></p>
+</div>
   <hr>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,10 +14,10 @@
       <%= render "layouts/header" %>
      </header>
         <main>
-         <%= render "layouts/flash" %>
+          <%= render "layouts/flash" %>
           <%# max_width メソッドは application_helper.rb に記載 %>
           <div class="base-container <%= max_width %>">
-            <%= yield %>
+           <%= yield %>
           </div>
         </main>
      <footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
       <%= render "layouts/header" %>
      </header>
         <main>
+         <%= render "layouts/flash" %>
           <%# max_width メソッドは application_helper.rb に記載 %>
           <div class="base-container <%= max_width %>">
             <%= yield %>


### PR DESCRIPTION
close #12

## 実装内容

- フラッシュの表示機能

- ナビバー同様，横幅一杯とすること（mainタグの開始タグすぐ下）
     - 直接`application.html.erb`に書き込まず，部分テンプレート 
　　　- `app/views/layouts/_flash.html.erb`を作成して読み込むようにすること
　　　

## 参考資料

-  [【公式】Bootstrap（Alerts）](https://getbootstrap.jp/docs/4.5/components/alerts/)

- フラッシュメッセージ表示

　- [【やんばるエキスパート教材】メッセージ投稿アプリ その2](https://www.yanbaru-code.com/texts/270)
　

- フラッシュで Bootstrap の アラート を利用

　- [【やんばるエキスパート教材】メッセージ投稿アプリ その3](https://www.yanbaru-code.com/texts/271)


## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
