### PR TITLE
Railsテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -6,7 +6,7 @@ div.card_area {
     margin-bottom: 50px;
 }
 div.card{
-    width: 374px;
+    max-width: 376px;
     height:376px;
     
 }

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,0 +1,14 @@
+h1{
+    text-align: center;
+}
+
+div.card_area {
+    // margin-right: 9px;
+    // margin-left: 9px;
+    margin-bottom: 50px;
+}
+div.card{
+    width: 374px;
+    height:376px;
+    
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where.not(genre: "php").order(id: :asc)
+    @texts = Text.where(genre: Text::RAILS_GENRE_LIST).order(id: :asc)
   end
 
   def show; end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,7 @@
 class TextsController < ApplicationController
-  def index; end
+  def index
+    @texts = Text.where.not(genre: "php").order(id: :asc)
+  end
 
   def show; end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,6 @@
 class Text < ApplicationRecord
+  RAILS_GENRE_LIST = %w[basic git ruby rails]
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,12 +1,12 @@
-  <div class="card_area col-12 col-md-6 col-lg-4 p-0 ">
+  <div class="card_area col-12 col-md-6 col-lg-4">
   <div class="card mx-auto">
     <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" class="card-img-top" alt="カードの画像">
     <div class="card-body">
       <div class="row mx-auto">
-      <a href="#" class="btn btn-primary w-100">Go somewhere</a>
+      <a href="#" class="btn bg-secondary w-100" style = "color: white;">読破済みボタン</a>
       </div>
       <h5 class="card-title"><%= text.title %></h5>
-      <p class="card-text">[<%= text.genre %>]</p>
+      <p class="card-text">【<%= text.genre %>】</p>
     </div>
   </div>
 </div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,0 +1,10 @@
+  <div class="card_area col-12 col-md-6 col-lg-4 p-0 ">
+  <div class="card mx-auto">
+    <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" class="card-img-top" alt="カードの画像">
+    <div class="card-body">
+      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <h5 class="card-title"><%= text.title %></h5>
+      <p class="card-text">[<%= text.genre %>]</p>
+    </div>
+  </div>
+</div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -2,7 +2,9 @@
   <div class="card mx-auto">
     <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" class="card-img-top" alt="カードの画像">
     <div class="card-body">
-      <a href="#" class="btn btn-primary">Go somewhere</a>
+      <div class="row mx-auto">
+      <a href="#" class="btn btn-primary w-100">Go somewhere</a>
+      </div>
       <h5 class="card-title"><%= text.title %></h5>
       <p class="card-text">[<%= text.genre %>]</p>
     </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,0 +1,13 @@
+<h1>Ruby/Rails テキスト教材</h1>
+<table>
+  <thead>
+    
+  </thead>
+  <tbody>
+
+      <div class="row">
+      <%= render @texts %>
+      </div>
+    
+  </tbody>
+</table>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,5 +1,4 @@
 <h1>Ruby/Rails テキスト教材</h1>
-<table>
   <thead>
     
   </thead>
@@ -10,4 +9,3 @@
       </div>
     
   </tbody>
-</table>


### PR DESCRIPTION
close #13 

## 実装内容
- app/models/text.rb に次を定義
  - RAILS_GENRE_LIST = %w[basic git ruby rails]
- Railsテキスト教材の一覧ページを作成
 - Bootstrapの Cards や Grid System を用いて見た目を作成
 - コントローラーを編集してPHPのジャンルを非表示に。
 - 見た目の調整はIndex.html.erbと_text.html.erbとtexts.scsに記述。


## 参考資料（必要があれば）
- PHPの情報を取得しないコントローラーの記述
  - https://qiita.com/Hal_mai/items/babb19560ace072c99f5
- Bootstrapにボタンなどについて
 - https://pera-lab.com/archives/2436
 - https://www.granfairs.com/blog/staff/centering-by-css  

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要があれば）


## 備考（必要があれば）
