### PR TITLE
ゲストログイン機能の実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,7 +44,7 @@ Style/SymbolArray:
 Metrics/BlockLength:
   Exclude:
     - 'app/admin/*'
-    - "config/environments/**/*"
+    - 'config/environments/**/*'
 
 Rails/Output:
   Exclude:

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,6 @@
+class Users::SessionsController < Devise::SessionsController
+  def guest_sign_in
+    sign_in User.guest
+    redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,8 @@
-class Users::SessionsController < Devise::SessionsController
-  def guest_sign_in
-    sign_in User.guest
-    redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+module Users
+  class SessionsController < Devise::SessionsController
+    def guest_sign_in
+      sign_in User.guest
+      redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
+
+  def self.guest
+    find_or_create_by!(email: "test@example.com") do |user|
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
 end

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,4 +1,7 @@
 <div class="form-group">
+  <%- if controller_name != 'seesions'%>
+    <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post,  class: "btn btn-block btn-success form-control my-3 text-white'" %>
+  <% end -%>
   <%- if controller_name != 'sessions' %>
     <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'btn btn-block btn-secondary form-control my-3 text-white' %><br />
   <% end -%>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,6 @@
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <li class="nav-item dropdown">
@@ -30,6 +29,7 @@
       <% else %>
         <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active text-light" %>
         <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active text-light" %>
+        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post,  class: "nav-item nav-link active text-light" %>
       <% end %>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   root to: "texts#index"
   devise_for :users
-
+  devise_scope :user do
+    post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
+  end
   resources :texts, only: [:index, :show]
   resources :movies, only: [:index]
 end


### PR DESCRIPTION
close #20

## 実装内容

- ゲストログイン機能の実装
 - ナビバーにゲストログインのリンクを追加
 - メールアドレスは`test@example.com`に指定

## 参考資料（必要があれば）

[【やんばるエキスパート教材】ゲストログイン機能の実装](https://www.yanbaru-code.com/texts/392)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 備考（必要があれば）
`rubocop -a`実行
`app/controllers/users/sessions_controller.rb:1`にて、ネストしたクラス名が違反。
>Class Users::SessionsController < Devise::SessionsController

`.rubocop.yml`に違反を許可する設定にすると反対にネストのないクラスが違反者になる様子。
```
ClassAndModuleChildren:
  EnforcedStyle: compact
```

今回は`git commit -n`で違反をパスしましたが、今後`rubocop -a`を走らせるたびにプロジェクト全員が違反を警告される可能性があると思いました。

>Class Users::SessionsController < Devise::SessionsController
ネストを解消してみようと試みましたが、継承元のネストの扱いがわかりませんでした。

今回の場合はどのように対処するべきでしょか。