### PR TITLE
動画教材のページネーションを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,4 +37,5 @@ end
 
 gem "activeadmin"
 gem "devise-bootstrap-views", "~> 1.0"
+gem "kaminari"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,7 @@ DEPENDENCIES
   devise-i18n
   enum_help
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   pg (~> 1.1)
   pre-commit

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,7 @@
 class MoviesController < ApplicationController
+  PER_PAGE = 12
+
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -3,5 +3,7 @@ class MoviesController < ApplicationController
 
   def index
     @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
+    page = @movies.current_page
+    @movie_counter = (page - 1) * PER_PAGE
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -3,7 +3,5 @@ class MoviesController < ApplicationController
 
   def index
     @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
-    page = @movies.current_page
-    @movie_counter = (page - 1) * PER_PAGE
   end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,5 @@
 class Text < ApplicationRecord
-  RAILS_GENRE_LIST = %w[basic git ruby rails]
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
   with_options presence: true do
     validates :genre

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination justify-content-center">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,11 +1,13 @@
-<div class="card-base col-sm-6 col-md-4">
-  <div class="card border-dark">
-    <div class="embed-responsive embed-responsive-16by9">
-      <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
-    </div>
-    <div class="card-body rails-card-body">
-      <a href="#" class="btn btn-dokuha btn-secondary">読破済みにする</a>
-      <p class="card-title rails-card-title">Lv.<%= "#{movie_counter +1}" %>：<%= movie.title %></p>
+<% @movies.each.with_index(1) do |movie, index| %>
+  <div class="card-base col-sm-6 col-md-4">
+    <div class="card border-dark">
+      <div class="embed-responsive embed-responsive-16by9">
+        <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
+      </div>
+      <div class="card-body rails-card-body">
+        <a href="#" class="btn btn-dokuha btn-secondary">読破済みにする</a>
+        <p class="card-title rails-card-title">Lv.<%= "#{@movie_counter + index}" %>：<%= movie.title %></p>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,4 +1,4 @@
-<% @movies.each.with_index(1) do |movie, index| %>
+<% @movies.each.with_index(@movies.offset_value + 1) do |movie, index| %>
   <div class="card-base col-sm-6 col-md-4">
     <div class="card border-dark">
       <div class="embed-responsive embed-responsive-16by9">

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,13 +1,11 @@
-<% @movies.each.with_index(@movies.offset_value + 1) do |movie, index| %>
-  <div class="card-base col-sm-6 col-md-4">
-    <div class="card border-dark">
-      <div class="embed-responsive embed-responsive-16by9">
-        <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
-      </div>
-      <div class="card-body rails-card-body">
-        <a href="#" class="btn btn-dokuha btn-secondary">読破済みにする</a>
-        <p class="card-title rails-card-title">Lv.<%= "#{@movie_counter + index}" %>：<%= movie.title %></p>
-      </div>
+<div class="card-base col-sm-6 col-md-4">
+  <div class="card border-dark">
+    <div class="embed-responsive embed-responsive-16by9">
+      <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
+    </div>
+    <div class="card-body rails-card-body">
+      <a href="#" class="btn btn-dokuha btn-secondary">読破済みにする</a>
+      <p class="card-title rails-card-title">Lv.<%= "#{movie_counter + @movies.offset_value + 1}"%>：<%= movie.title %></p>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,7 +1,7 @@
 <h1 class="rails-movies-title">Ruby/Rails 動画</h1>
 <div class="container-fluid">
   <div class="row">
-    <%= render partial: "movie", collection: @movies %>
+    <%= render partial: "movie" %>
   </div>
 </div>
 <%= paginate @movies%>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -4,3 +4,4 @@
     <%= render partial: "movie", collection: @movies %>
   </div>
 </div>
+<%= paginate @movies%>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,7 +1,7 @@
 <h1 class="rails-movies-title">Ruby/Rails 動画</h1>
 <div class="container-fluid">
   <div class="row">
-    <%= render partial: "movie" %>
+    <%= render partial: "movie", collection: @movies %>
   </div>
 </div>
 <%= paginate @movies%>


### PR DESCRIPTION
close #22 

## 実装内容

- Gem kaminari をインストール
- 動画教材ページにページネーションを実装
  - 1ページの表示数は 12 件とすること

- ページネーションに Bootstrap を適用
  - `rails g kaminari:views bootstrap4`
 - ページネーションを中央寄せにする


## 参考資料（必要があれば）

[やんばるエキスパート教材】検索機能(Ransack)](https://www.yanbaru-code.com/texts/221)
[【Rails】kaminariでページネーションを実装](https://qiita.com/d0ne1s/items/58c3d0e08ce7ede94384)
[Kaminariとeach.with_indexを組み合わせて連番表示させる方法について](https://teratail.com/questions/326563)
[Bootstrap4移行ガイド
](https://v4.bootstrap-guide.com/components/pagination)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行


## 備考（必要があれば）
- 2ページ目以降のレベル表示を連番にする（未完成）
  - offset_value を利用

連番出力が意図した動作をせず。