### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,13 +1,5 @@
 class MoviesController < ApplicationController
   def index
     @movies = Movie.genre_classification(params[:genre])
-    # if params[:genre] == "php"
-    #   @movies = Movie.where(genre: :php).includes(:watch_progresses)
-    #   @title = "PHP動画"
-    # else
-    #   @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
-    #   @title = "Ruby/Rails 動画"
-    # end
-    # @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,12 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
+    if params[:genre] == "php"
+      @movies = Movie.where(genre: :php).includes(:watch_progresses)
+      @title = "PHP動画"
+    else
+      @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
+      @title = "Ruby/Rails 動画"
+    end
+    # @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,12 +1,13 @@
 class MoviesController < ApplicationController
   def index
-    if params[:genre] == "php"
-      @movies = Movie.where(genre: :php).includes(:watch_progresses)
-      @title = "PHP動画"
-    else
-      @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
-      @title = "Ruby/Rails 動画"
-    end
+    @movies = Movie.genre_classification(params[:genre])
+    # if params[:genre] == "php"
+    #   @movies = Movie.where(genre: :php).includes(:watch_progresses)
+    #   @title = "PHP動画"
+    # else
+    #   @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
+    #   @title = "Ruby/Rails 動画"
+    # end
     # @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def page_title(genre)
+    if genre == "php"
+      "PHP動画"
+    else
+      "Ruby/Rails 動画"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,10 +11,6 @@ module ApplicationHelper
   end
 
   def page_title(genre)
-    if genre == "php"
-      "PHP動画"
-    else
-      "Ruby/Rails 動画"
-    end
+    genre == "php" ? "PHP動画" : "Ruby/Rails 動画"
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -8,18 +8,8 @@ class Movie < ApplicationRecord
   def self.genre_classification(genre)
     if genre == "php"
       where(genre: :php).includes(:watch_progresses)
-      # @title = "PHP動画"
     else
       where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
-      # @title = "Ruby/Rails 動画"
-    end
-  end
-
-  def page_title
-    if genre == "php"
-      "php"
-    else
-      "rails"
     end
   end
 

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -5,6 +5,24 @@ class Movie < ApplicationRecord
     watch_progresses.any? { |watch_progress| watch_progress.user_id == user.id }
   end
 
+  def self.genre_classification(genre)
+    if genre == "php"
+      where(genre: :php).includes(:watch_progresses)
+      # @title = "PHP動画"
+    else
+      where(genre: Movie::RAILS_GENRE_LIST).includes(:watch_progresses)
+      # @title = "Ruby/Rails 動画"
+    end
+  end
+
+  def page_title
+    if genre == "php"
+      "php"
+    else
+      "rails"
+    end
+  end
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="rails-movies-title">Ruby/Rails 動画</h1>
+<h1 class="rails-movies-title"><%= @title %></h1>
 <div class="container-fluid">
   <div class="row">
     <%= render partial: "movie", collection: @movies %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="rails-movies-title"><%= @title %></h1>
+<h1 class="rails-movies-title"><%= page_title(params[:genre]) %></h1>
 <div class="container-fluid">
   <div class="row">
     <%= render partial: "movie", collection: @movies %>


### PR DESCRIPTION
close #19

## 実装内容
- 動画教材をジャンル分けするクラスメソッドを作成
- ページタイトルを表示するカスタムペルパーを作成

## 参考資料
[【Qiita】クラスメソッド、インスタンスメソッドの使い方](https://qiita.com/s_tatsuki/items/71874675c42e39c79524)
[【Qiita】ヘルパー(カスタムヘルパー)ってなんぞ？](https://qiita.com/sanstktkrsyhsk/items/67e9d88b939ccdcf46e8)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行