### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -2,6 +2,6 @@ class MoviesController < ApplicationController
   PER_PAGE = 12
 
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
+    @movies = Movie.genre_classification(params[:genre]).page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST).order(id: :asc)
+    @texts = Text.genre_classification(params[:genre]).order(id: :asc)
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,10 +11,6 @@ module ApplicationHelper
   end
 
   def page_title(genre)
-    genre == "php" ? "PHP動画" : "Ruby/Rails 動画"
-  end
-
-  def page_text(genre)
-    genre == "php" ? "PHPテキスト教材ページ" : "Ruby/Rails テキスト教材"
+    genre == "php" ? "PHP" : "Ruby/Rails"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,8 @@ module ApplicationHelper
   def page_title(genre)
     genre == "php" ? "PHP動画" : "Ruby/Rails 動画"
   end
+
+  def page_text(genre)
+    genre == "php" ? "PHPテキスト教材ページ" : "Ruby/Rails テキスト教材"
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,6 +1,14 @@
 class Text < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
+  def self.genre_classification(genre)
+    if genre == "php"
+      where(genre: :php)
+    else
+      where(genre: Text::RAILS_GENRE_LIST)
+    end
+  end
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="rails-movies-title"><%= page_title(params[:genre]) %></h1>
+<h1 class="rails-movies-title"><%= page_title(params[:genre]) %>動画</h1>
 <div class="container-fluid">
   <div class="row">
     <%= render partial: "movie", collection: @movies %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,9 +1,8 @@
-<h1>Ruby/Rails テキスト教材</h1>
-  <thead>
-    
-  </thead>
-  <tbody>
-        <div class="row">
-          <%= render @texts %>
-        </div>
-  </tbody>
+<h1><%= page_text(params[:genre]) %></h1>
+<thead>
+</thead>
+<tbody>
+  <div class="row">
+    <%= render @texts %>
+  </div>
+</tbody>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= page_text(params[:genre]) %></h1>
+<h1><%= page_title(params[:genre]) %>テキスト教材</h1>
 <thead>
 </thead>
 <tbody>


### PR DESCRIPTION
close #21

## 実装内容

- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする


## 参考資料（必要があれば）

[ヨスケさんのコードを参考](https://github.com/yanbaru-expert/team_project_52/pull/46/files)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 備考（必要があれば）
>「タスク18」の app/helpers/application_helper.rb にメソッドを利用して対応できるとなおよいでしょう
力不足によりメソッドを分けての実装になります。